### PR TITLE
PYMT-696 [Part 1] Updated Client class with new ES commands

### DIFF
--- a/src/Interfaces/ClientInterface.php
+++ b/src/Interfaces/ClientInterface.php
@@ -34,4 +34,73 @@ interface ClientInterface
      * @return void
      */
     public function bulkUpdate(string $index, array $documents): void;
+
+    /**
+     * Create a new alias for specified index
+     *
+     * @param string $indexName
+     * @param string $aliasName
+     *
+     * @return void
+     */
+    public function createAlias(string $indexName, string $aliasName): void;
+
+    /**
+     * Create a new index
+     *
+     * @param string $name
+     * @param mixed[]|null $mappings
+     * @param mixed[]|null $settings
+     *
+     * @return void
+     */
+    public function createIndex(
+        string $name,
+        ?array $mappings = null,
+        ?array $settings = null
+    ): void;
+
+    /**
+     * Delete an existing alias
+     *
+     * @param string $indexName
+     * @param string $aliasName
+     *
+     * @return void
+     */
+    public function deleteAlias(string $indexName, string $aliasName): void;
+
+    /**
+     * Delete an existing index
+     *
+     * @param string $name
+     *
+     * @return void
+     */
+    public function deleteIndex(string $name): void;
+
+    /**
+     * Determine if alias exists
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function isAlias(string $name): bool;
+
+    /**
+     * Determine if index exists
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function isIndex(string $name): bool;
+
+    /**
+     * List all existing indexes
+     *
+     * @return mixed[]
+     */
+    public function listIndices(): array;
 }


### PR DESCRIPTION
Key changes:
- `ClientInterface` is now bound as a service in the Laravel container (bridge)
- `createAlias`, `createIndex`, `deleteAlias`, `deleteIndex`, `isAlias`, `isIndex`, `listIndices` added to `ClientInterface` and Client

Notes:
- No tests yet
- isAlias, isIndex probably don't need to exist, it can be determined by the consumer and using `listIndices` perhaps
- `listIndices` has one argument (`?bool $includeAliases`) because it's much more organised and less expensive to integrate into one aggregate method

Questions:
- There is probably too many public methods on `ClientInterface`, is a BC break okay to decouple the client logically into sub-classes `bulk`, `index`, `alias`?
- Is the responsibility of the `Manager` purely SearchHandler related? I presume it's not going to be touched with this task

P.S. Tested with simple script and it's all functional
```
<?php
declare(strict_types=1);

use Elasticsearch\ClientBuilder;

include('vendor/autoload.php');

$client = new \LoyaltyCorp\Search\Client(
    ClientBuilder::create()->setHosts(['https://admin:admin@127.0.0.1:9200'])->setSSLVerification(false)->build()
);

try {
    $root = 'resource';
    $index = \sprintf('%s_%s', $root, \time());
    $tempAlias = \sprintf('%s_new', $root);

    // #1.
    $client->createIndex($index);

    // Remove _new alias if already exists
    if ($client->isAlias($tempAlias) === true) {
        $client->deleteAlias($root, $tempAlias);
    }
    $client->createAlias($index, $tempAlias);

    // #2. Populate documents into indice...
    // not relevant to this purpose

    //Swap or rm + add
    if ($client->isAlias($root) === true) {
        $client->deleteAlias('*', $root);
    }

    // #3.
    $client->createAlias($index, $root);

    // #4.
    $client->deleteIndex($index);

    $indices = $client->listIndices(true);
    \xdebug_break();

} catch (\Exception $exception) {
    \xdebug_break();
}
```