### PR TITLE
Fix issues where  could still be empty

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -61,7 +61,7 @@ final class Client implements ClientInterface
         try {
             $this->elastic->bulk(['body' => $bulk]);
         } catch (Exception $exception) {
-            throw new SearchDeleteException('An error occured while performing bulk delete on backend', 0, $exception);
+            throw new SearchDeleteException('An error occurred while performing bulk delete on backend', 0, $exception);
         }
     }
 
@@ -89,7 +89,7 @@ final class Client implements ClientInterface
         try {
             $this->elastic->bulk(['body' => $bulk]);
         } catch (Exception $exception) {
-            throw new SearchUpdateException('An error occured while performing bulk update on backend', 0, $exception);
+            throw new SearchUpdateException('An error occurred while performing bulk update on backend', 0, $exception);
         }
     }
 }

--- a/src/Interfaces/ClientInterface.php
+++ b/src/Interfaces/ClientInterface.php
@@ -29,7 +29,7 @@ interface ClientInterface
      * Upserts all documents provided into the index.
      *
      * @param string $index
-     * @param string[][] $documents
+     * @param mixed[][] $documents
      *
      * @return void
      */

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -100,6 +100,12 @@ final class Manager implements ManagerInterface
                 $transformed[(string)$searchId] = $document;
             }
 
+            if (\count($transformed) === 0) {
+                // there were no transformed documents created by the handler, we have
+                // nothing to update
+                continue;
+            }
+
             $this->client->bulkUpdate($handler->getIndexName(), $transformed);
         }
     }

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -74,12 +74,32 @@ final class ManagerTest extends TestCase
             new NoSearchIdStub(),
             new SearchableStub()
         ]);
+
         self::assertSame(
             ['body' =>
                 [['index' => ['_index' => 'valid', '_type' => 'doc', '_id' => 'searchable']], ['search' => 'body']]
             ],
             $stub->getBulkParameters()
         );
+    }
+
+    /**
+     * Test handleUpdates() functionality when no transformations occur
+     *
+     * @return void
+     */
+    public function testHandleUpdatesWhenNoTransformationsOccur(): void
+    {
+        $stub = new ClientStub();
+        $manager = new Manager([new HandlerStub()], new Client($stub));
+
+        // Tests whats going to happen when handleUpdates is called with objects that result
+        // in no transformations
+        $manager->handleUpdates(SearchableStub::class, [
+            new NoDocumentBodyStub()
+        ]);
+
+        self::assertNull($stub->getBulkParameters());
     }
 
     /**

--- a/tests/Stubs/Handlers/Searches/NotSearchableStub.php
+++ b/tests/Stubs/Handlers/Searches/NotSearchableStub.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Tests\LoyaltyCorp\Search\Stubs\Handlers\Searches;
 
+/**
+ * @noinspection EmptyClassInspection Class is intentionally empty
+ */
 final class NotSearchableStub
 {
 }


### PR DESCRIPTION
When the handlers return null and refuse to transform an entity, we might still end up with an empty $transformed array which means we're trying to write nothing to ES.

Abort if we are in that condition.