### PR TITLE
Fixed issues with index swapping & counting

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -124,7 +124,8 @@ final class Client implements ClientInterface
         try {
             $count = $this->elastic->cat()->count(['index' => $index]);
 
-            return (int)$count['count'];
+            // _cat/_count supports counting many indices, the response is an array of objects but we only need 0 index
+            return (int)$count[0]['count'];
         } catch (Exception $exception) {
             throw new SearchCheckerException('Unable to count number of documents within index', 0, $exception);
         }

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -152,13 +152,19 @@ final class Indexer implements IndexerInterface
                 throw new AliasNotFoundException(\sprintf('Could not find expected alias \'%s\'', $newAlias));
             }
 
-            if ($this->elasticClient->count($newAlias) === 0 &&
+            if ($this->elasticClient->isAlias($searchHandler->getIndexName()) === true &&
+                $this->elasticClient->count($newAlias) === 0 &&
                 $this->elasticClient->count($searchHandler->getIndexName()) > 0) {
                 $indexToSkip[] = $latestAlias['index'];
                 $aliasedToRemove[] = $newAlias;
+                /**
+                 * Swapping should not occur if all the conditions are met:
+                 *     - The root alias exists
+                 *     - New index has no documents
+                 *     - Old index contains data
+                 * Generally this is true when the SearchIndex type is not entity based
+                 */
 
-                // Swapping should not occur. Old index contains data, new one does not support populating.
-                // Generally this is true when the SearchIndex type is not entity based
                 continue;
             }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -147,7 +147,7 @@ final class ClientTest extends TestCase
      */
     public function testCount(): void
     {
-        $response = ['count' => 5];
+        $response = [['count' => 5]];
         $elasticClient = $this->createElasticClient($response, 200);
         $client = $this->createInstance($elasticClient);
 


### PR DESCRIPTION
- Added more comments within the index swap code
- Fixed count response handlin
- Added check for index swap integrity check to ensure the root alias exists before attempting to count documents

P.S. /_cat/_count/{index} will return a 404 if the index/alias does not exist