### PR TITLE
Elasticsearch index name must be lowercase.

### DIFF
--- a/src/Transformers/DefaultIndexTransformer.php
+++ b/src/Transformers/DefaultIndexTransformer.php
@@ -14,7 +14,7 @@ final class DefaultIndexTransformer implements IndexTransformerInterface
      */
     public function transformIndexName(EntitySearchHandlerInterface $handler, object $object): string
     {
-        return $handler->getIndexName();
+        return \mb_strtolower($handler->getIndexName());
     }
 
     /**
@@ -23,7 +23,7 @@ final class DefaultIndexTransformer implements IndexTransformerInterface
     public function transformIndexNames(SearchHandlerInterface $searchHandler): array
     {
         return [
-            $searchHandler->getIndexName()
+            \mb_strtolower($searchHandler->getIndexName())
         ];
     }
 }


### PR DESCRIPTION
There was a bug where if the index name is not all lower case it throws exception.

Fix:
Convert index name to lowercase in `DefaultIndexTransformer`