### PR TITLE
PYMT-1414 search access

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     "doctrine/orm": "^2.6",
     "elasticsearch/elasticsearch": "^6.1",
     "eoneopay/externals": "^1.1",
+    "ext-json": "*",
     "guzzlehttp/guzzle": "^6.3",
     "illuminate/console": "^5.8|^6.0"
   },
   "require-dev": {
-    "ext-json": "*",
     "eoneopay/standards": "dev-master",
     "friendsofphp/php-cs-fixer": "^2.15",
     "guzzlehttp/psr7": "^1.5",

--- a/src/Access/AnonymousAccessPopulator.php
+++ b/src/Access/AnonymousAccessPopulator.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\Search\Access;
+
+use LoyaltyCorp\Search\Indexer\AccessTokenMappingHelper;
+use LoyaltyCorp\Search\Interfaces\Access\AccessPopulatorInterface;
+
+class AnonymousAccessPopulator implements AccessPopulatorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getAccessTokens(object $object): array
+    {
+        // All documents are anonymous by default. Implement your own service
+        // for AccessTransformerInterface to define access controls for the object.
+        $transformed[AccessTokenMappingHelper::ACCESS_TOKEN_PROPERTY] = ['anonymous'];
+
+        return $transformed;
+    }
+}

--- a/src/Access/AnonymousAccessPopulator.php
+++ b/src/Access/AnonymousAccessPopulator.php
@@ -3,10 +3,9 @@ declare(strict_types=1);
 
 namespace LoyaltyCorp\Search\Access;
 
-use LoyaltyCorp\Search\Indexer\AccessTokenMappingHelper;
 use LoyaltyCorp\Search\Interfaces\Access\AccessPopulatorInterface;
 
-class AnonymousAccessPopulator implements AccessPopulatorInterface
+final class AnonymousAccessPopulator implements AccessPopulatorInterface
 {
     /**
      * {@inheritdoc}
@@ -15,8 +14,6 @@ class AnonymousAccessPopulator implements AccessPopulatorInterface
     {
         // All documents are anonymous by default. Implement your own service
         // for AccessTransformerInterface to define access controls for the object.
-        $transformed[AccessTokenMappingHelper::ACCESS_TOKEN_PROPERTY] = ['anonymous'];
-
-        return $transformed;
+        return ['anonymous'];
     }
 }

--- a/src/Bridge/Laravel/Providers/SearchServiceProvider.php
+++ b/src/Bridge/Laravel/Providers/SearchServiceProvider.php
@@ -11,12 +11,14 @@ use EoneoPay\Externals\ORM\Interfaces\EntityManagerInterface as EoneoPayEntityMa
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
+use LoyaltyCorp\Search\Access\AnonymousAccessPopulator;
 use LoyaltyCorp\Search\Client;
 use LoyaltyCorp\Search\Exceptions\BindingResolutionException;
 use LoyaltyCorp\Search\Helpers\ClientBulkResponseHelper;
 use LoyaltyCorp\Search\Helpers\EntityManagerHelper;
 use LoyaltyCorp\Search\Helpers\RegisteredSearchHandler;
 use LoyaltyCorp\Search\Indexer;
+use LoyaltyCorp\Search\Interfaces\Access\AccessPopulatorInterface;
 use LoyaltyCorp\Search\Interfaces\ClientInterface;
 use LoyaltyCorp\Search\Interfaces\Helpers\ClientBulkResponseHelperInterface;
 use LoyaltyCorp\Search\Interfaces\Helpers\EntityManagerHelperInterface;
@@ -64,6 +66,8 @@ final class SearchServiceProvider extends ServiceProvider implements DeferrableP
      */
     public function register(): void
     {
+        $this->app->singleton(AccessPopulatorInterface::class, AnonymousAccessPopulator::class);
+
         // Bind elasticsearch client
         $this->app->singleton(ClientInterface::class, static function (Container $app): ClientInterface {
             return new Client(

--- a/src/Exceptions/InvalidMappingException.php
+++ b/src/Exceptions/InvalidMappingException.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\Search\Exceptions;
+
+class InvalidMappingException extends SearchException
+{
+}

--- a/src/Exceptions/InvalidSearchRequestException.php
+++ b/src/Exceptions/InvalidSearchRequestException.php
@@ -3,6 +3,6 @@ declare(strict_types=1);
 
 namespace LoyaltyCorp\Search\Exceptions;
 
-final class InvalidMappingException extends SearchException
+final class InvalidSearchRequestException extends SearchException
 {
 }

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -9,6 +9,8 @@ use LoyaltyCorp\Search\Exceptions\AliasNotFoundException;
 use LoyaltyCorp\Search\Indexer\IndexCleanResult;
 use LoyaltyCorp\Search\Indexer\IndexSwapResult;
 use LoyaltyCorp\Search\Interfaces\ClientInterface;
+use LoyaltyCorp\Search\Interfaces\CustomAccessHandlerInterface;
+use LoyaltyCorp\Search\Interfaces\Indexer\MappingHelperInterface;
 use LoyaltyCorp\Search\Interfaces\IndexerInterface;
 use LoyaltyCorp\Search\Interfaces\SearchHandlerInterface;
 use LoyaltyCorp\Search\Interfaces\Transformers\IndexNameTransformerInterface;
@@ -24,6 +26,11 @@ final class Indexer implements IndexerInterface
     private $elasticClient;
 
     /**
+     * @var MappingHelperInterface
+     */
+    private $mappingHelper;
+
+    /**
      * @var \LoyaltyCorp\Search\Interfaces\Transformers\IndexNameTransformerInterface
      */
     private $nameTransformer;
@@ -32,13 +39,16 @@ final class Indexer implements IndexerInterface
      * Constructor.
      *
      * @param \LoyaltyCorp\Search\Interfaces\ClientInterface $elasticClient
+     * @param MappingHelperInterface $mappingHelper
      * @param \LoyaltyCorp\Search\Interfaces\Transformers\IndexNameTransformerInterface $nameTransformer
      */
     public function __construct(
         ClientInterface $elasticClient,
+        MappingHelperInterface $mappingHelper,
         IndexNameTransformerInterface $nameTransformer
     ) {
         $this->elasticClient = $elasticClient;
+        $this->mappingHelper = $mappingHelper;
         $this->nameTransformer = $nameTransformer;
     }
 
@@ -115,7 +125,7 @@ final class Indexer implements IndexerInterface
 
             $this->elasticClient->createIndex(
                 $newIndex,
-                $searchHandler::getMappings(),
+                $this->mappingHelper->buildIndexMappings($searchHandler),
                 $searchHandler::getSettings()
             );
 

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -9,7 +9,6 @@ use LoyaltyCorp\Search\Exceptions\AliasNotFoundException;
 use LoyaltyCorp\Search\Indexer\IndexCleanResult;
 use LoyaltyCorp\Search\Indexer\IndexSwapResult;
 use LoyaltyCorp\Search\Interfaces\ClientInterface;
-use LoyaltyCorp\Search\Interfaces\CustomAccessHandlerInterface;
 use LoyaltyCorp\Search\Interfaces\Indexer\MappingHelperInterface;
 use LoyaltyCorp\Search\Interfaces\IndexerInterface;
 use LoyaltyCorp\Search\Interfaces\SearchHandlerInterface;
@@ -26,7 +25,7 @@ final class Indexer implements IndexerInterface
     private $elasticClient;
 
     /**
-     * @var MappingHelperInterface
+     * @var \LoyaltyCorp\Search\Interfaces\Indexer\MappingHelperInterface
      */
     private $mappingHelper;
 
@@ -39,7 +38,7 @@ final class Indexer implements IndexerInterface
      * Constructor.
      *
      * @param \LoyaltyCorp\Search\Interfaces\ClientInterface $elasticClient
-     * @param MappingHelperInterface $mappingHelper
+     * @param \LoyaltyCorp\Search\Interfaces\Indexer\MappingHelperInterface $mappingHelper
      * @param \LoyaltyCorp\Search\Interfaces\Transformers\IndexNameTransformerInterface $nameTransformer
      */
     public function __construct(

--- a/src/Indexer/AccessTokenMappingHelper.php
+++ b/src/Indexer/AccessTokenMappingHelper.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\Search\Indexer;
+
+use LoyaltyCorp\Search\Exceptions\InvalidMappingException;
+use LoyaltyCorp\Search\Interfaces\CustomAccessHandlerInterface;
+use LoyaltyCorp\Search\Interfaces\Indexer\MappingHelperInterface;
+use LoyaltyCorp\Search\Interfaces\SearchHandlerInterface;
+
+final class AccessTokenMappingHelper implements MappingHelperInterface
+{
+    /**
+     * Defines the property that is used to store access tokens in the document
+     * inside elasticsearch.
+     *
+     * Any proxying code should make a best effort to remove this property from being
+     * returned to the user.
+     *
+     * @const string
+     */
+    public const ACCESS_TOKEN_PROPERTY = '_access_tokens';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \LoyaltyCorp\Search\Exceptions\InvalidMappingException
+     */
+    public function buildIndexMappings(SearchHandlerInterface $searchHandler): array
+    {
+        $mappings = $searchHandler::getMappings();
+
+        // If the search handler implements CustomAccessHandlerInterface it is indicating
+        // it does its own thing regarding access control.
+        if ($searchHandler instanceof CustomAccessHandlerInterface === true) {
+            return $mappings;
+        }
+
+        // Add our extra mappings for access control.
+        return $this->addAccessMappings($mappings);
+    }
+
+    /**
+     * Adds access mappings to the index.
+     *
+     * @param mixed[] $mappings
+     *
+     * @return mixed[]
+     *
+     * @throws \LoyaltyCorp\Search\Exceptions\InvalidMappingException
+     */
+    private function addAccessMappings(array $mappings): array
+    {
+        // Find what should be the only key in the mappings array root,
+        // which is the type name (a deprecated elasticsearch feature)
+        $key = \array_key_first($mappings);
+
+        // If there is no key, or we have more than one entry in mappings
+        // we've got something we dont know how to modify.
+        if ($key === null || \count($mappings) !== 1) {
+            throw new InvalidMappingException(
+                'Unknown mapping format. Mapping must return a multidimensional array with a single key.'
+            );
+        }
+
+        // Add a property for access tokens
+        return \array_merge_recursive($mappings, [
+            $key => [
+                'properties' => [
+                    self::ACCESS_TOKEN_PROPERTY => [
+                        'type' => 'keyword'
+                    ]
+                ]
+            ]
+        ]);
+    }
+}

--- a/src/Indexer/AccessTokenMappingHelper.php
+++ b/src/Indexer/AccessTokenMappingHelper.php
@@ -68,10 +68,10 @@ final class AccessTokenMappingHelper implements MappingHelperInterface
             $key => [
                 'properties' => [
                     self::ACCESS_TOKEN_PROPERTY => [
-                        'type' => 'keyword'
-                    ]
-                ]
-            ]
+                        'type' => 'keyword',
+                    ],
+                ],
+            ],
         ]);
     }
 }

--- a/src/Interfaces/Access/AccessPopulatorInterface.php
+++ b/src/Interfaces/Access/AccessPopulatorInterface.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\Search\Interfaces\Access;
+
+interface AccessPopulatorInterface
+{
+    /**
+     * Any implementation of this service should return the access tokens
+     * to associate with the object that is passed. When passed, the object
+     * is being transformed into a search document and should have any
+     * access tokens embedded in that document for access control.
+     *
+     * @param object $object
+     *
+     * @return string[]
+     */
+    public function getAccessTokens(object $object): array;
+}

--- a/src/Interfaces/CustomAccessHandlerInterface.php
+++ b/src/Interfaces/CustomAccessHandlerInterface.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\Search\Interfaces;
+
+/**
+ * This interface is used to signal to the search package that the
+ * search handler wants to opt out of access controls. Implementing
+ * this interface means that the _access key is not added to mapping
+ * and that when populating the index, no access tokens are generated
+ * for a document.
+ */
+interface CustomAccessHandlerInterface
+{
+}

--- a/src/Interfaces/Indexer/MappingHelperInterface.php
+++ b/src/Interfaces/Indexer/MappingHelperInterface.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace LoyaltyCorp\Search\Interfaces\Indexer;
+
+use LoyaltyCorp\Search\Interfaces\SearchHandlerInterface;
+
+interface MappingHelperInterface
+{
+    /**
+     * Builds mappings from a search handler which may optionally modify the
+     * mappings.
+     *
+     * @param \LoyaltyCorp\Search\Interfaces\SearchHandlerInterface $searchHandler
+     *
+     * @return mixed[]
+     */
+    public function buildIndexMappings(SearchHandlerInterface $searchHandler): array;
+}

--- a/src/Interfaces/ResponseFactoryInterface.php
+++ b/src/Interfaces/ResponseFactoryInterface.php
@@ -11,9 +11,19 @@ interface ResponseFactoryInterface
     /**
      * Sends request and strips out CORS headers before returning a response.
      *
+     * Pass in an array of access tokens that the request should be granted that
+     * can be built based on the authenticated user, the multi tenant identifier or
+     * other conditions that should limit the search results to anything that only
+     * contains the access tokens specified. The tokens are considered an or list
+     * and any match will allow the document to be returned.
+     *
      * @param \Psr\Http\Message\RequestInterface $request
+     * @param string[]|null $accessTokens
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
-    public function sendRequest(RequestInterface $request): ResponseInterface;
+    public function sendRequest(
+        RequestInterface $request,
+        ?array $accessTokens = null
+    ): ResponseInterface;
 }

--- a/src/ResponseFactory.php
+++ b/src/ResponseFactory.php
@@ -5,8 +5,10 @@ namespace LoyaltyCorp\Search;
 
 use EoneoPay\Externals\HttpClient\Interfaces\ClientInterface;
 use LoyaltyCorp\Search\Interfaces\ResponseFactoryInterface;
+use LoyaltyCorp\Search\Interfaces\Access\AccessPopulatorInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use function GuzzleHttp\Psr7\stream_for;
 
 final class ResponseFactory implements ResponseFactoryInterface
 {
@@ -28,8 +30,11 @@ final class ResponseFactory implements ResponseFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function sendRequest(RequestInterface $request): ResponseInterface
-    {
+    public function sendRequest(
+        RequestInterface $request,
+        ?array $accessTokens = null
+    ): ResponseInterface {
+        $request = $this->addAccessControl($request, $accessTokens);
         $response = $this->client->sendRequest($request);
 
         $response = $response
@@ -42,5 +47,54 @@ final class ResponseFactory implements ResponseFactoryInterface
             ->withoutHeader('Access-Control-Max-Age');
 
         return $response;
+    }
+
+    /**
+     * Injects access control related parts into the search request.
+     *
+     * @param RequestInterface $request
+     * @param array $accessTokens
+     *
+     * @return RequestInterface
+     */
+    private function addAccessControl(RequestInterface $request, array $accessTokens): RequestInterface
+    {
+        if ($request->getBody()->isSeekable() === true) {
+            $request->getBody()->rewind();
+        }
+
+        $body = \json_decode(
+            $request->getBody()->getContents(),
+            true,
+            512,
+            \JSON_THROW_ON_ERROR
+        );
+
+        // If the search request doesnt have
+        $query = $body['query'] ?? ['match_all' => []];
+
+        // Exclude the access field from the _source key of results
+        $body['_source'] = [
+            'excludes' => [AccessPopulatorInterface::ACCESS_TOKEN_PROPERTY]
+        ];
+
+        // Wrap the entire query in a bool/filter
+        $body['query'] = [
+            'bool' => [
+                'should' => $query
+            ],
+            'filter' => [
+                [
+                    'term' => [
+                        AccessPopulatorInterface::ACCESS_TOKEN_PROPERTY => $accessTokens ?: ['anonymous']
+                    ]
+                ]
+            ]
+        ];
+
+        $modifiedBody = stream_for(\json_encode($body, \JSON_THROW_ON_ERROR));
+
+        return $request->withMethod('POST')
+            ->withBody($modifiedBody);
     }
 }

--- a/tests/Access/AnonymousAccessPopulatorTest.php
+++ b/tests/Access/AnonymousAccessPopulatorTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Search\Access;
+
+use LoyaltyCorp\Search\Access\AnonymousAccessPopulator;
+use stdClass;
+use Tests\LoyaltyCorp\Search\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\Search\Access\AnonymousAccessPopulator
+ */
+final class AnonymousAccessPopulatorTest extends TestCase
+{
+    /**
+     * Tests that the anonymous access populator returns an anonymous access
+     * token.
+     *
+     * @return void
+     */
+    public function testAnonymous(): void
+    {
+        $populator = new AnonymousAccessPopulator();
+        $expected = ['anonymous'];
+
+        $tokens = $populator->getAccessTokens(new stdClass());
+
+        self::assertSame($expected, $tokens);
+    }
+}

--- a/tests/Indexer/AccessTokenMappingHelperTest.php
+++ b/tests/Indexer/AccessTokenMappingHelperTest.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Search\Indexer;
+
+use LoyaltyCorp\Search\Exceptions\InvalidMappingException;
+use LoyaltyCorp\Search\Indexer\AccessTokenMappingHelper;
+use Tests\LoyaltyCorp\Search\Stubs\Handlers\CustomAccessHandlerStub;
+use Tests\LoyaltyCorp\Search\Stubs\Handlers\InvalidMappingHandlerStub;
+use Tests\LoyaltyCorp\Search\Stubs\Handlers\TransformableSearchHandlerStub;
+use Tests\LoyaltyCorp\Search\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\Search\Indexer\AccessTokenMappingHelper
+ */
+final class AccessTokenMappingHelperTest extends TestCase
+{
+    /**
+     * Tests what happens when the AccessTokenMappingHelper is passed a handler
+     * that implements CustomAccessHandlerInterface.
+     *
+     * @return void
+     */
+    public function testCustomAccess(): void
+    {
+        $helper = new AccessTokenMappingHelper();
+
+        $handler = new CustomAccessHandlerStub();
+
+        $expectedMappings = ['mappings'];
+
+        $mappings = $helper->buildIndexMappings($handler);
+
+        self::assertSame($expectedMappings, $mappings);
+    }
+
+    /**
+     * Tests that the helper adds _access_tokens key to the mapping.
+     *
+     * @return void
+     */
+    public function testAccessMappings(): void
+    {
+        $helper = new AccessTokenMappingHelper();
+
+        $handler = new TransformableSearchHandlerStub();
+
+        $expectedMappings = [
+            'doc' => [
+                'dynamic' => 'strict',
+                'properties' => [
+                    'createdAt' => [
+                        'type' => 'date',
+                    ],
+                    '_access_tokens' => [
+                        'type' => 'keyword',
+                    ],
+                ],
+            ],
+        ];
+
+        $mappings = $helper->buildIndexMappings($handler);
+
+        self::assertSame($expectedMappings, $mappings);
+    }
+
+    /**
+     * Tests when the mapping the handler returns isnt valid based on the
+     * narrow assumptions that the helper makes (single root key).
+     *
+     * @return void
+     */
+    public function testAccessMappingsInvalid(): void
+    {
+        $helper = new AccessTokenMappingHelper();
+
+        $handler = new InvalidMappingHandlerStub();
+
+        $this->expectException(InvalidMappingException::class);
+        $this->expectExceptionMessage(
+            'Unknown mapping format. Mapping must return a multidimensional array with a single key.'
+        );
+
+        $helper->buildIndexMappings($handler);
+    }
+}

--- a/tests/IndexerTest.php
+++ b/tests/IndexerTest.php
@@ -6,6 +6,7 @@ namespace Tests\LoyaltyCorp\Search;
 use EoneoPay\Utils\DateTime;
 use LoyaltyCorp\Search\Exceptions\AliasNotFoundException;
 use LoyaltyCorp\Search\Indexer;
+use LoyaltyCorp\Search\Indexer\AccessTokenMappingHelper;
 use LoyaltyCorp\Search\Indexer\IndexSwapResult;
 use LoyaltyCorp\Search\Interfaces\ClientInterface;
 use LoyaltyCorp\Search\Transformers\DefaultIndexNameTransformer;
@@ -37,9 +38,13 @@ final class IndexerTest extends TestCase
             'name' => 'valid_20190102030405',
             'mappings' => [
                 'doc' => [
+                    'dynamic' => 'strict',
                     'properties' => [
                         'createdAt' => [
                             'type' => 'date',
+                        ],
+                        '_access_tokens' => [
+                            'type' => 'keyword',
                         ],
                     ],
                 ],
@@ -281,6 +286,7 @@ final class IndexerTest extends TestCase
     ): Indexer {
         return new Indexer(
             $client ?? new ClientStub(),
+            new AccessTokenMappingHelper(),
             new DefaultIndexNameTransformer()
         );
     }

--- a/tests/PopulatorTest.php
+++ b/tests/PopulatorTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Tests\LoyaltyCorp\Search;
 
+use LoyaltyCorp\Search\Access\AnonymousAccessPopulator;
 use LoyaltyCorp\Search\DataTransferObjects\DocumentUpdate;
 use LoyaltyCorp\Search\Interfaces\ClientInterface;
 use LoyaltyCorp\Search\Interfaces\Transformers\IndexNameTransformerInterface;
@@ -17,6 +18,8 @@ use Tests\LoyaltyCorp\Search\Stubs\Handlers\TransformableSearchHandlerStub;
 
 /**
  * @covers \LoyaltyCorp\Search\Populator
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects) required to test
  */
 final class PopulatorTest extends TestCase
 {
@@ -34,10 +37,18 @@ final class PopulatorTest extends TestCase
 
         $expected = [
             [
-                new DocumentUpdate('valid_suffix', 'search1', ['search' => 'body']),
+                new DocumentUpdate(
+                    'valid_suffix',
+                    'search1',
+                    ['search' => 'body', '_access_tokens' => ['anonymous']]
+                ),
             ],
             [
-                new DocumentUpdate('valid_suffix', 'search2', ['search' => 'body']),
+                new DocumentUpdate(
+                    'valid_suffix',
+                    'search2',
+                    ['search' => 'body', '_access_tokens' => ['anonymous']]
+                ),
             ],
         ];
 
@@ -86,8 +97,16 @@ final class PopulatorTest extends TestCase
 
         $expected = [
             [
-                new DocumentUpdate('valid_suffix', 'search1', ['search' => 'body']),
-                new DocumentUpdate('valid_suffix', 'search2', ['search' => 'body']),
+                new DocumentUpdate(
+                    'valid_suffix',
+                    'search1',
+                    ['search' => 'body', '_access_tokens' => ['anonymous']]
+                ),
+                new DocumentUpdate(
+                    'valid_suffix',
+                    'search2',
+                    ['search' => 'body', '_access_tokens' => ['anonymous']]
+                ),
             ],
         ];
 
@@ -141,11 +160,23 @@ final class PopulatorTest extends TestCase
 
         $expected = [
             [
-                new DocumentUpdate('valid_suffix', 'search1', ['search' => 'body']),
-                new DocumentUpdate('valid_suffix', 'search2', ['search' => 'body']),
+                new DocumentUpdate(
+                    'valid_suffix',
+                    'search1',
+                    ['search' => 'body', '_access_tokens' => ['anonymous']]
+                ),
+                new DocumentUpdate(
+                    'valid_suffix',
+                    'search2',
+                    ['search' => 'body', '_access_tokens' => ['anonymous']]
+                ),
             ],
             [
-                new DocumentUpdate('valid_suffix', 'search3', ['search' => 'body']),
+                new DocumentUpdate(
+                    'valid_suffix',
+                    'search3',
+                    ['search' => 'body', '_access_tokens' => ['anonymous']]
+                ),
             ],
         ];
 
@@ -172,7 +203,11 @@ final class PopulatorTest extends TestCase
 
         $expected = [
             [
-                new DocumentUpdate('valid_suffix', 'search1', ['search' => 'body']),
+                new DocumentUpdate(
+                    'valid_suffix',
+                    'search1',
+                    ['search' => 'body', '_access_tokens' => ['anonymous']]
+                ),
             ],
         ];
 
@@ -199,6 +234,7 @@ final class PopulatorTest extends TestCase
         ?IndexNameTransformerInterface $nameTransformer = null
     ): Populator {
         return new Populator(
+            new AnonymousAccessPopulator(),
             $client ?? new ClientStub(),
             $nameTransformer ?? new DefaultIndexNameTransformer()
         );

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -8,9 +8,12 @@ use EoneoPay\Externals\HttpClient\ExceptionHandler;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
+use LoyaltyCorp\Search\Exceptions\InvalidSearchRequestException;
 use LoyaltyCorp\Search\ResponseFactory;
+use Zend\Diactoros\Response\TextResponse;
 use Zend\Diactoros\ServerRequest;
 use function GuzzleHttp\Psr7\str;
+use function GuzzleHttp\Psr7\stream_for;
 
 /**
  * @covers \LoyaltyCorp\Search\ResponseFactory
@@ -37,10 +40,161 @@ final class ResponseFactoryTest extends TestCase
 
         $client = new Client(new GuzzleClient(['handler' => new MockHandler([$response])]), new ExceptionHandler());
         $service = new ResponseFactory($client);
-        $request = new ServerRequest();
+
+        $request = new ServerRequest([], [], null, 'POST', stream_for('{}'));
 
         $result = $service->sendRequest($request);
 
         self::assertSame(str($expectedResponse), str($result));
+    }
+
+    /**
+     * Tests what happens when an empty request body is proxied.
+     *
+     * @return void
+     */
+    public function testAccessControlEmptyBody(): void
+    {
+        $response = new TextResponse('RESPONSE');
+
+        $mockHandler = new MockHandler([$response]);
+        $client = new Client(
+            new GuzzleClient([
+                'handler' => $mockHandler,
+            ]),
+            new ExceptionHandler()
+        );
+        $service = new ResponseFactory($client);
+
+        $expectedData = [
+            '_source' => [
+                'excludes' => [
+                    '_access_tokens',
+                ],
+            ],
+            'query' => [
+                'bool' => [
+                    'should' => [
+                        'match_all' => [],
+                    ],
+                    'filter' => [
+                        ['term' => ['_access_tokens' => ['anonymous']]],
+                    ],
+                ],
+            ],
+        ];
+        $expectedRequest = new ServerRequest(
+            [],
+            [],
+            null,
+            'POST',
+            stream_for(
+                \json_encode($expectedData, \JSON_THROW_ON_ERROR)
+            )
+        );
+
+        $request = new ServerRequest([], [], null, 'POST', stream_for(''));
+
+        $service->sendRequest($request);
+
+        $actual = $mockHandler->getLastRequest()
+            ->withoutHeader('user-agent');
+
+        self::assertSame(str($expectedRequest), str($actual));
+    }
+
+    /**
+     * Tests what happens when an empty request body is proxied.
+     *
+     * @return void
+     */
+    public function testAccessControl(): void
+    {
+        $response = new TextResponse('RESPONSE');
+
+        $mockHandler = new MockHandler([$response]);
+        $client = new Client(
+            new GuzzleClient([
+                'handler' => $mockHandler,
+            ]),
+            new ExceptionHandler()
+        );
+        $service = new ResponseFactory($client);
+
+        $expectedData = [
+            'query' => [
+                'bool' => [
+                    'should' => [
+                        'term' => [
+                            'user' => [
+                                'value' => 'tim',
+                            ],
+                        ],
+                    ],
+                    'filter' => [
+                        ['term' => ['_access_tokens' => ['access-secret', 'purple-elephants']]],
+                    ],
+                ],
+            ],
+            '_source' => [
+                'excludes' => [
+                    '_access_tokens',
+                ],
+            ],
+        ];
+        $expectedRequest = new ServerRequest(
+            [],
+            [],
+            null,
+            'POST',
+            stream_for(
+                \json_encode($expectedData, \JSON_THROW_ON_ERROR)
+            )
+        );
+
+        $request = new ServerRequest(
+            [],
+            [],
+            null,
+            'POST',
+            stream_for('{"query": {"term": {"user": {"value": "tim"}}}}')
+        );
+
+        $service->sendRequest($request, ['access-secret', 'purple-elephants']);
+
+        $actual = $mockHandler->getLastRequest()
+            ->withoutHeader('user-agent');
+
+        self::assertSame(str($expectedRequest), str($actual));
+    }
+
+    /**
+     * Tests what happens when a request contains invalid json.
+     *
+     * @return void
+     */
+    public function testAccessControlBadJson(): void
+    {
+        $mockHandler = new MockHandler([]);
+        $client = new Client(
+            new GuzzleClient([
+                'handler' => $mockHandler,
+            ]),
+            new ExceptionHandler()
+        );
+        $service = new ResponseFactory($client);
+
+        $request = new ServerRequest(
+            [],
+            [],
+            null,
+            'POST',
+            stream_for('invalid[]')
+        );
+
+        $this->expectException(InvalidSearchRequestException::class);
+        $this->expectExceptionMessage('An exception occurred while trying to decode the json request.');
+
+        $service->sendRequest($request);
     }
 }

--- a/tests/Stubs/Handlers/CustomAccessHandlerStub.php
+++ b/tests/Stubs/Handlers/CustomAccessHandlerStub.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Search\Stubs\Handlers;
+
+use LoyaltyCorp\Search\Interfaces\CustomAccessHandlerInterface;
+use LoyaltyCorp\Search\Interfaces\TransformableSearchHandlerInterface;
+use Tests\LoyaltyCorp\Search\Stubs\Entities\EntityStub;
+
+/**
+ * @coversNothing
+ */
+final class CustomAccessHandlerStub implements CustomAccessHandlerInterface, TransformableSearchHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getMappings(): array
+    {
+        return ['mappings'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSettings(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFillIterable(): iterable
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHandledClasses(): array
+    {
+        return [EntityStub::class];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIndexName(): string
+    {
+        return 'entity_stub';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchId(object $object)
+    {
+        return \method_exists($object, 'getSearchId') ? $object->getSearchId() : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($object = null): ?array
+    {
+        return [];
+    }
+}

--- a/tests/Stubs/Handlers/InvalidMappingHandlerStub.php
+++ b/tests/Stubs/Handlers/InvalidMappingHandlerStub.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Search\Stubs\Handlers;
+
+use LoyaltyCorp\Search\Interfaces\TransformableSearchHandlerInterface;
+use Tests\LoyaltyCorp\Search\Stubs\Entities\EntityStub;
+
+/**
+ * @coversNothing
+ */
+final class InvalidMappingHandlerStub implements TransformableSearchHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getMappings(): array
+    {
+        return ['doc' => [], 'not-doc' => []];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSettings(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFillIterable(): iterable
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHandledClasses(): array
+    {
+        return [EntityStub::class];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIndexName(): string
+    {
+        return 'entity_stub';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchId(object $object)
+    {
+        return \method_exists($object, 'getSearchId') ? $object->getSearchId() : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($object = null): ?array
+    {
+        return [];
+    }
+}

--- a/tests/Stubs/Handlers/TransformableSearchHandlerStub.php
+++ b/tests/Stubs/Handlers/TransformableSearchHandlerStub.php
@@ -40,6 +40,7 @@ final class TransformableSearchHandlerStub implements TransformableSearchHandler
     {
         return [
             'doc' => [
+                'dynamic' => 'strict',
                 'properties' => [
                     'createdAt' => [
                         'type' => 'date',


### PR DESCRIPTION
This PR is for the implementation of access tokens + document filtering with elasticsearch.

By introducing a key on the document (`_access_tokens`) that stores access tokens resolved for each object by the application, the search proxying process can add a filter to the query that filters away any documents that do not match against the specified filter.

- The mapping process has been modified to add the _access_tokens mapping field to every index (with an opt out method that doesnt break BC - implement the CustomAccessHandlerInterface)
- The populator service is modified to add access keys to the document with a default anonymous implementation. The application is expected to implement the interface and return usable data (In subscriptions, the provider id will be an access token, in payments the actioning user and user will be access tokens)
- The response factory is modified to add granted access tokens to the query. The calling controller must work out what access tokens the user should be granted.

**Move ticket back to analysis please**