### PR TITLE
PYMT-1479: Health Stats

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,6 +15,3 @@ parameters:
         -
             message: '#Tests\\LoyaltyCorp\\Search\\Stubs\\CatStub::__construct\(\) does not call parent constructor from Elasticsearch\\Namespaces\\AbstractNamespace.#'
             path: tests/Stubs/CatStub.php
-        -
-            message: '#Method Tests\\LoyaltyCorp\\Search\\Stubs\\Vendor\\Elasticsearch\\CallableResponseClientStub::bulk\(\) should return array but returns GuzzleHttp\\Ring\\Future\\FutureArray\.#'
-            path: tests/Stubs/Vendor/Elasticsearch/CallableResponseClientStub.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,3 +15,6 @@ parameters:
         -
             message: '#Tests\\LoyaltyCorp\\Search\\Stubs\\CatStub::__construct\(\) does not call parent constructor from Elasticsearch\\Namespaces\\AbstractNamespace.#'
             path: tests/Stubs/CatStub.php
+        -
+            message: '#Method Tests\\LoyaltyCorp\\Search\\Stubs\\Vendor\\Elasticsearch\\CallableResponseClientStub::bulk\(\) should return array but returns GuzzleHttp\\Ring\\Future\\FutureArray\.#'
+            path: tests/Stubs/Vendor/Elasticsearch/CallableResponseClientStub.php

--- a/src/Client.php
+++ b/src/Client.php
@@ -5,6 +5,7 @@ namespace LoyaltyCorp\Search;
 
 use Elasticsearch\Client as BaseClient;
 use Exception;
+use LoyaltyCorp\Search\DataTransferObjects\ClusterHealth;
 use LoyaltyCorp\Search\Exceptions\SearchCheckerException;
 use LoyaltyCorp\Search\Exceptions\SearchDeleteException;
 use LoyaltyCorp\Search\Exceptions\SearchUpdateException;
@@ -210,6 +211,21 @@ final class Client implements ClientInterface
             return \array_values($aliases);
         } catch (Exception $exception) {
             throw new SearchCheckerException('An error occurred obtaining a list of aliases', 0, $exception);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHealth(): ClusterHealth
+    {
+        try {
+            $cluster = $this->elastic->cluster();
+            $result = $cluster->health();
+
+            return new ClusterHealth($result);
+        } catch (Exception $exception) {
+            throw new SearchCheckerException('An error occurred checking the cluster health', 0, $exception);
         }
     }
 

--- a/src/DataTransferObjects/ClusterHealth.php
+++ b/src/DataTransferObjects/ClusterHealth.php
@@ -1,0 +1,293 @@
+<?php /** @noinspection PhpPropertyNamingConventionInspection Long property names to keep inline with ES API. */
+declare(strict_types=1);
+
+namespace LoyaltyCorp\Search\DataTransferObjects;
+
+/**
+ * @SuppressWarnings(PHPMD.LongVariable) Long variable names to keep inline with Elasticsearch API.
+ */
+class ClusterHealth
+{
+    /**
+     * The number of active primary shards.
+     *
+     * @var int
+     */
+    private $activePrimaryShards;
+
+    /**
+     * The number of active shards.
+     *
+     * @var int
+     */
+    private $activeShards;
+
+    /**
+     * The percentage of active shards.
+     *
+     * @var int
+     */
+    private $activeShardsPercent;
+
+    /**
+     * The number of delayed unassigned shards.
+     *
+     * @var int
+     */
+    private $delayedUnassignedShards;
+
+    /**
+     * The number of initializing shards.
+     *
+     * @var int
+     */
+    private $initializingShards;
+
+    /**
+     * The name of the cluster.
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * The number of data nodes.
+     *
+     * @var int
+     */
+    private $numberOfDataNodes;
+
+    /**
+     * The number of in-flight fetches.
+     *
+     * @var int
+     */
+    private $numberOfInFlightFetch;
+
+    /**
+     * The number of nodes.
+     *
+     * @var int
+     */
+    private $numberOfNodes;
+
+    /**
+     * The number of pending tasks.
+     *
+     * @var int
+     */
+    private $numberOfPendingTasks;
+
+    /**
+     * The number of relocating shards.
+     *
+     * @var int
+     */
+    private $relocatingShards;
+
+    /**
+     * The cluster status.
+     *
+     * @var string
+     */
+    private $status;
+
+    /**
+     * The maximum waiting time (in milliseconds) for a queued task.
+     *
+     * @var int
+     */
+    private $taskMaxWaitingInQueueMillis;
+
+    /**
+     * Whether the health report timed out.
+     *
+     * @var bool
+     */
+    private $timedOut;
+
+    /**
+     * The number of unassigned shards.
+     *
+     * @var int
+     */
+    private $unassignedShards;
+
+    /**
+     * Constructs a new instance of the DTO.
+     *
+     * @param mixed[] $data The response data from the Elasticsearch API.
+     *
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/6.8/cluster-health.html
+     */
+    public function __construct(array $data)
+    {
+        $this->activePrimaryShards = (int)$data['active_primary_shards'];
+        $this->activeShards = (int)$data['active_shards'];
+        $this->activeShardsPercent = (int)$data['active_shards_percent_as_number'];
+        $this->delayedUnassignedShards = (int)$data['delayed_unassigned_shards'];
+        $this->initializingShards = (int)$data['initializing_shards'];
+        $this->name = (string)$data['cluster_name'];
+        $this->numberOfDataNodes = (int)$data['number_of_data_nodes'];
+        $this->numberOfInFlightFetch = (int)$data['number_of_in_flight_fetch'];
+        $this->numberOfNodes = (int)$data['number_of_nodes'];
+        $this->numberOfPendingTasks = (int)$data['number_of_pending_tasks'];
+        $this->relocatingShards = (int)$data['relocating_shards'];
+        $this->status = (string)$data['status'];
+        $this->taskMaxWaitingInQueueMillis = (int)$data['task_max_waiting_in_queue_millis'];
+        $this->timedOut = (bool)$data['timed_out'];
+        $this->unassignedShards = (int)$data['unassigned_shards'];
+    }
+
+    /**
+     * Gets the number of active shards as a percentage.
+     *
+     * @return int
+     */
+    public function getActiveShardsPercent(): int
+    {
+        return $this->activeShardsPercent;
+    }
+
+    /**
+     * Gets the cluster name.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Gets the number of active primary shards.
+     *
+     * @return int
+     */
+    public function getNumberOfActivePrimaryShards(): int
+    {
+        return $this->activePrimaryShards;
+    }
+
+    /**
+     * Gets the number of active shards.
+     *
+     * @return int
+     */
+    public function getNumberOfActiveShards(): int
+    {
+        return $this->activeShards;
+    }
+
+    /**
+     * Gets the number of data nodes.
+     *
+     * @return int
+     *
+     */
+    public function getNumberOfDataNodes(): int
+    {
+        return $this->numberOfDataNodes;
+    }
+
+    /**
+     * Gets the number of delayed unassigned shards.
+     *
+     * @return int
+     */
+    public function getNumberOfDelayedUnassignedShards(): int
+    {
+        return $this->delayedUnassignedShards;
+    }
+
+    /**
+     * Gets the number of in-flight fetches.
+     *
+     * @return int
+     */
+    public function getNumberOfInFlightFetch(): int
+    {
+        return $this->numberOfInFlightFetch;
+    }
+
+    /**
+     * Gets the number of initializing shards.
+     *
+     * @return int
+     */
+    public function getNumberOfInitializingShards(): int
+    {
+        return $this->initializingShards;
+    }
+
+    /**
+     * Gets the number of nodes in the cluster.
+     *
+     * @return int
+     */
+    public function getNumberOfNodes(): int
+    {
+        return $this->numberOfNodes;
+    }
+
+    /**
+     * Gets the number of pending tasks.
+     *
+     * @return int
+     */
+    public function getNumberOfPendingTasks(): int
+    {
+        return $this->numberOfPendingTasks;
+    }
+
+    /**
+     * Gets the number of relocating shards.
+     *
+     * @return int
+     */
+    public function getNumberOfRelocatingShards(): int
+    {
+        return $this->relocatingShards;
+    }
+
+    /**
+     * Gets the number of unassigned shards.
+     *
+     * @return int
+     *
+     */
+    public function getNumberOfUnassignedShards(): int
+    {
+        return $this->unassignedShards;
+    }
+
+    /**
+     * Gets the cluster status.
+     *
+     * @return string
+     */
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    /**
+     * Gets the maximum waiting time (in milliseconds) for a queued task.
+     *
+     * @return int
+     */
+    public function getTaskMaxWaitingInQueueMillis(): int
+    {
+        return $this->taskMaxWaitingInQueueMillis;
+    }
+
+    /**
+     * Gets whether the health report timed out.
+     *
+     * @return bool
+     */
+    public function hasTimedOut(): bool
+    {
+        return $this->timedOut;
+    }
+}

--- a/src/DataTransferObjects/ClusterHealth.php
+++ b/src/DataTransferObjects/ClusterHealth.php
@@ -6,7 +6,7 @@ namespace LoyaltyCorp\Search\DataTransferObjects;
 /**
  * @SuppressWarnings(PHPMD.LongVariable) Long variable names to keep inline with Elasticsearch API.
  */
-class ClusterHealth
+final class ClusterHealth
 {
     /**
      * The number of active primary shards.
@@ -183,7 +183,6 @@ class ClusterHealth
      * Gets the number of data nodes.
      *
      * @return int
-     *
      */
     public function getNumberOfDataNodes(): int
     {
@@ -254,7 +253,6 @@ class ClusterHealth
      * Gets the number of unassigned shards.
      *
      * @return int
-     *
      */
     public function getNumberOfUnassignedShards(): int
     {

--- a/src/Interfaces/ClientInterface.php
+++ b/src/Interfaces/ClientInterface.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace LoyaltyCorp\Search\Interfaces;
 
+use LoyaltyCorp\Search\DataTransferObjects\ClusterHealth;
+
 interface ClientInterface
 {
     /**
@@ -94,6 +96,13 @@ interface ClientInterface
      * @return string[][]
      */
     public function getAliases(?string $name = null): array;
+
+    /**
+     * Gets the health of the cluster.
+     *
+     * @return \LoyaltyCorp\Search\DataTransferObjects\ClusterHealth
+     */
+    public function getHealth(): ClusterHealth;
 
     /**
      * List all existing indexes.

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -22,6 +22,7 @@ use Tests\LoyaltyCorp\Search\Stubs\Vendor\Elasticsearch\ClientStub;
  *
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects) Required for thorough testing
  * @SuppressWarnings(PHPMD.TooManyPublicMethods) Well tested code for all the cases.
+ * @SuppressWarnings(PHPMD.TooManyMethods) Required for testing
  */
 final class ClientTest extends TestCase
 {
@@ -306,6 +307,69 @@ final class ClientTest extends TestCase
     }
 
     /**
+     * Tests that the 'getHealth' method returns the expected DTO values.
+     *
+     * @return void
+     */
+    public function testGetHealth(): void
+    {
+        $response = [
+            'cluster_name' => 'testcluster',
+            'status' => 'yellow',
+            'timed_out' => false,
+            'number_of_nodes' => 1,
+            'number_of_data_nodes' => 1,
+            'active_primary_shards' => 5,
+            'active_shards' => 5,
+            'relocating_shards' => 0,
+            'initializing_shards' => 0,
+            'unassigned_shards' => 5,
+            'delayed_unassigned_shards' => 0,
+            'number_of_pending_tasks' => 0,
+            'number_of_in_flight_fetch' => 0,
+            'task_max_waiting_in_queue_millis' => 0,
+            'active_shards_percent_as_number' => 50.0,
+        ];
+        $client = $this->createElasticClient($response, 200);
+        $instance = $this->createInstance($client);
+
+        $result = $instance->getHealth();
+
+        self::assertSame('testcluster', $result->getName());
+        self::assertSame('yellow', $result->getStatus());
+        self::assertFalse($result->hasTimedOut());
+        self::assertSame(1, $result->getNumberOfNodes());
+        self::assertSame(1, $result->getNumberOfDataNodes());
+        self::assertSame(5, $result->getNumberOfActivePrimaryShards());
+        self::assertSame(5, $result->getNumberOfActiveShards());
+        self::assertSame(0, $result->getNumberOfRelocatingShards());
+        self::assertSame(0, $result->getNumberOfInitializingShards());
+        self::assertSame(5, $result->getNumberOfUnassignedShards());
+        self::assertSame(0, $result->getNumberOfDelayedUnassignedShards());
+        self::assertSame(0, $result->getNumberOfPendingTasks());
+        self::assertSame(0, $result->getNumberOfInFlightFetch());
+        self::assertSame(0, $result->getTaskMaxWaitingInQueueMillis());
+        self::assertSame(50, $result->getActiveShardsPercent());
+    }
+
+    /**
+     * Tests that the 'getHealth' method throws an exception when the Elasticsearch response is not as documented,
+     * and creation of the DTO fails.
+     *
+     * @return void
+     */
+    public function testGetHealthThrowsExceptionWithInvalidResponse(): void
+    {
+        $client = $this->createElasticClient(['something' => 'here'], 200);
+        $instance = $this->createInstance($client);
+
+        $this->expectException(SearchCheckerException::class);
+        $this->expectExceptionMessage('An error occurred checking the cluster health');
+
+        $instance->getHealth();
+    }
+
+    /**
      * Ensure the isAlias method respects HTTP status code.
      *
      * @return void
@@ -519,10 +583,7 @@ final class ClientTest extends TestCase
             throw new AssertionFailedError('Unable to open in-memory resource for mocked guzzle handler');
         }
 
-        if (\fwrite(
-            $stream,
-            \json_encode($response, \JSON_THROW_ON_ERROR)
-        ) === false) {
+        if (\fwrite($stream, \json_encode($response, \JSON_THROW_ON_ERROR)) === false) {
             throw new AssertionFailedError('Unable to write to in-memory resource for mocked guzzle handler');
         }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -360,7 +360,7 @@ final class ClientTest extends TestCase
      */
     public function testGetHealthThrowsExceptionWithInvalidResponse(): void
     {
-        $client = $this->createElasticClient(['something' => 'here'], 200);
+        $client = $this->createElasticClient([], 500);
         $instance = $this->createInstance($client);
 
         $this->expectException(SearchCheckerException::class);

--- a/tests/DataTransferObjects/ClusterHealthTest.php
+++ b/tests/DataTransferObjects/ClusterHealthTest.php
@@ -9,7 +9,7 @@ use Tests\LoyaltyCorp\Search\TestCase;
 /**
  * @covers \LoyaltyCorp\Search\DataTransferObjects\ClusterHealth
  */
-class ClusterHealthTest extends TestCase
+final class ClusterHealthTest extends TestCase
 {
     /**
      * Tests the DTO getters.
@@ -33,7 +33,7 @@ class ClusterHealthTest extends TestCase
             'number_of_pending_tasks' => 9,
             'number_of_in_flight_fetch' => 10,
             'task_max_waiting_in_queue_millis' => 11,
-            'active_shards_percent_as_number' => 50.0
+            'active_shards_percent_as_number' => 50.0,
         ];
 
         $instance = new ClusterHealth($data);

--- a/tests/DataTransferObjects/ClusterHealthTest.php
+++ b/tests/DataTransferObjects/ClusterHealthTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\LoyaltyCorp\Search\DataTransferObjects;
+
+use LoyaltyCorp\Search\DataTransferObjects\ClusterHealth;
+use Tests\LoyaltyCorp\Search\TestCase;
+
+/**
+ * @covers \LoyaltyCorp\Search\DataTransferObjects\ClusterHealth
+ */
+class ClusterHealthTest extends TestCase
+{
+    /**
+     * Tests the DTO getters.
+     *
+     * @return void
+     */
+    public function testMethods(): void
+    {
+        $data = [
+            'cluster_name' => 'testcluster',
+            'status' => 'yellow',
+            'timed_out' => false,
+            'number_of_nodes' => 1,
+            'number_of_data_nodes' => 2,
+            'active_primary_shards' => 3,
+            'active_shards' => 4,
+            'relocating_shards' => 5,
+            'initializing_shards' => 6,
+            'unassigned_shards' => 7,
+            'delayed_unassigned_shards' => 8,
+            'number_of_pending_tasks' => 9,
+            'number_of_in_flight_fetch' => 10,
+            'task_max_waiting_in_queue_millis' => 11,
+            'active_shards_percent_as_number' => 50.0
+        ];
+
+        $instance = new ClusterHealth($data);
+
+        self::assertSame('testcluster', $instance->getName());
+        self::assertSame('yellow', $instance->getStatus());
+        self::assertFalse($instance->hasTimedOut());
+        self::assertSame(1, $instance->getNumberOfNodes());
+        self::assertSame(2, $instance->getNumberOfDataNodes());
+        self::assertSame(3, $instance->getNumberOfActivePrimaryShards());
+        self::assertSame(4, $instance->getNumberOfActiveShards());
+        self::assertSame(5, $instance->getNumberOfRelocatingShards());
+        self::assertSame(6, $instance->getNumberOfInitializingShards());
+        self::assertSame(7, $instance->getNumberOfUnassignedShards());
+        self::assertSame(8, $instance->getNumberOfDelayedUnassignedShards());
+        self::assertSame(9, $instance->getNumberOfPendingTasks());
+        self::assertSame(10, $instance->getNumberOfInFlightFetch());
+        self::assertSame(11, $instance->getTaskMaxWaitingInQueueMillis());
+        self::assertSame(50, $instance->getActiveShardsPercent());
+    }
+}

--- a/tests/Stubs/ClientStub.php
+++ b/tests/Stubs/ClientStub.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Tests\LoyaltyCorp\Search\Stubs;
 
+use LoyaltyCorp\Search\DataTransferObjects\ClusterHealth;
 use LoyaltyCorp\Search\Interfaces\ClientInterface;
 
 /**
@@ -43,6 +44,11 @@ final class ClientStub implements ClientInterface
     private $deletedIndices = [];
 
     /**
+     * @var \LoyaltyCorp\Search\DataTransferObjects\ClusterHealth|null
+     */
+    private $health;
+
+    /**
      * @var mixed[]
      */
     private $indices;
@@ -75,19 +81,22 @@ final class ClientStub implements ClientInterface
      * @param mixed[]|null $indices
      * @param mixed[]|null $aliases
      * @param int[]|null $count
+     * @param \LoyaltyCorp\Search\DataTransferObjects\ClusterHealth|null $health
      */
     public function __construct(
         ?bool $isAlias = null,
         ?bool $isIndex = null,
         ?array $indices = null,
         ?array $aliases = null,
-        ?array $count = null
+        ?array $count = null,
+        ?ClusterHealth $health = null
     ) {
         $this->aliases = $aliases ?? [];
         $this->indices = $indices ?? [];
         $this->isAlias = $isAlias ?? false;
         $this->isIndex = $isIndex ?? false;
         $this->count = \array_reverse($count ?? []);
+        $this->health = $health;
     }
 
     /**
@@ -193,6 +202,30 @@ final class ClientStub implements ClientInterface
     public function getDeletedIndices(): array
     {
         return $this->deletedIndices;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHealth(): ClusterHealth
+    {
+        return $this->health ?? new ClusterHealth([
+                'cluster_name' => 'testcluster',
+                'status' => 'yellow',
+                'timed_out' => false,
+                'number_of_nodes' => 1,
+                'number_of_data_nodes' => 2,
+                'active_primary_shards' => 3,
+                'active_shards' => 4,
+                'relocating_shards' => 5,
+                'initializing_shards' => 6,
+                'unassigned_shards' => 7,
+                'delayed_unassigned_shards' => 8,
+                'number_of_pending_tasks' => 9,
+                'number_of_in_flight_fetch' => 10,
+                'task_max_waiting_in_queue_millis' => 11,
+                'active_shards_percent_as_number' => 50.0,
+            ]);
     }
 
     /**

--- a/tests/Stubs/Vendor/Elasticsearch/ClientStub.php
+++ b/tests/Stubs/Vendor/Elasticsearch/ClientStub.php
@@ -32,7 +32,7 @@ final class ClientStub extends Client
      *
      * Create stub
      *
-     * @param bool|null $throwException Whether a call to bulk() should throw an exception or not
+     * @param bool|null $throwException Whether calls should throw an exception or not
      */
     public function __construct(?bool $throwException = null)
     {


### PR DESCRIPTION
This PR implements the ability to fetch Elasticsearch cluster health, with the results being populated in to a structured DTO. This will be used by the health check service to obtain detailed information about Elasticsearch clusters, rather than relying on whether we can fetch indices, or not.

**Related to ticket:** https://eonx.atlassian.net/browse/PYMT-1479