### PR TITLE
PYMT-1595 Whitelist RequestProxyFactory

### DIFF
--- a/src/RequestProxyFactory.php
+++ b/src/RequestProxyFactory.php
@@ -8,6 +8,11 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Uri;
 
+/**
+ * Proxy requests to an ElasticSearch instance.
+ *
+ * Passes on whitelisted headers only.s
+ */
 final class RequestProxyFactory implements RequestProxyFactoryInterface
 {
     /**

--- a/src/RequestProxyFactory.php
+++ b/src/RequestProxyFactory.php
@@ -63,7 +63,7 @@ final class RequestProxyFactory implements RequestProxyFactoryInterface
         }
 
         // Strip all headers.
-        foreach ($request->getHeaders() as $headerKey => $_) {
+        foreach (\array_keys($request->getHeaders()) as $headerKey) {
             $request = $request->withoutHeader($headerKey);
         }
 

--- a/src/RequestProxyFactory.php
+++ b/src/RequestProxyFactory.php
@@ -62,13 +62,14 @@ final class RequestProxyFactory implements RequestProxyFactoryInterface
             $request = $request->withoutAttribute('_encoder');
         }
 
-        // Strip any authentication headers from the request.
-        $request = $request->withoutHeader('Authorization');
+        // Strip all headers.
+        foreach ($request->getHeaders() as $headerKey => $_) {
+            $request = $request->withoutHeader($headerKey);
+        }
 
         $userInfo = $searchUri->getUserInfo();
         if ($userInfo !== '') {
             // If the URI had a userinfo component, add an Authorization header.
-
             $request = $request->withHeader(
                 'Authorization',
                 \sprintf('Basic %s', \base64_encode($userInfo))
@@ -76,9 +77,7 @@ final class RequestProxyFactory implements RequestProxyFactoryInterface
         }
 
         return $request
-            // Remove the original Content-Length - the underlying Http Client will repopulate
-            ->withoutHeader('Content-Length')
-            // Force a json content type
+            // ElasticSearch requests are always Content-Type: application/json.
             ->withHeader(
                 'Content-Type',
                 'application/json'

--- a/tests/RequestProxyFactoryTest.php
+++ b/tests/RequestProxyFactoryTest.php
@@ -25,7 +25,8 @@ final class RequestProxyFactoryTest extends TestCase
             [],
             'https://subscriptions.system.example/search/index/_doc/_search?pp=5',
             'POST',
-            stream_for('request body')
+            stream_for('request body'),
+            ['Origin' => 'https://eonx.example.org']
         );
         $request = $request->withAttribute('_encoder', 'value');
 
@@ -38,6 +39,7 @@ final class RequestProxyFactoryTest extends TestCase
 
         self::assertSame($expectedUri, (string)$result->getUri());
         self::assertSame($expectedAuth, $result->getHeaderLine('Authorization'));
+        self::assertSame('', $result->getHeaderLine('Origin'));
         self::assertSame('request body', (string)$result->getBody());
         self::assertInstanceOf(ServerRequest::class, $result);
         self::assertNull(($result instanceof ServerRequest) ? $result->getAttribute('_encoder') : '');
@@ -56,7 +58,8 @@ final class RequestProxyFactoryTest extends TestCase
             [],
             'https://subscriptions.system.example/search/index/_doc/_search?pp=5',
             'POST',
-            stream_for('request body')
+            stream_for('request body'),
+            ['BadHeader' => 'BadValue']
         );
         $request = $request->withAttribute('_encoder', 'value');
 
@@ -68,6 +71,7 @@ final class RequestProxyFactoryTest extends TestCase
 
         self::assertSame($expectedUri, (string)$result->getUri());
         self::assertSame('', $result->getHeaderLine('Authorization'));
+        self::assertSame('', $result->getHeaderLine('BadHeader'));
         self::assertSame('request body', (string)$result->getBody());
         self::assertInstanceOf(ServerRequest::class, $result);
         self::assertNull(($result instanceof ServerRequest) ? $result->getAttribute('_encoder') : '');

--- a/tests/RequestProxyFactoryTest.php
+++ b/tests/RequestProxyFactoryTest.php
@@ -39,6 +39,7 @@ final class RequestProxyFactoryTest extends TestCase
 
         self::assertSame($expectedUri, (string)$result->getUri());
         self::assertSame($expectedAuth, $result->getHeaderLine('Authorization'));
+        self::assertSame('', $result->getHeaderLine('Content-Length'));
         self::assertSame('', $result->getHeaderLine('Origin'));
         self::assertSame('request body', (string)$result->getBody());
         self::assertInstanceOf(ServerRequest::class, $result);
@@ -59,7 +60,7 @@ final class RequestProxyFactoryTest extends TestCase
             'https://subscriptions.system.example/search/index/_doc/_search?pp=5',
             'POST',
             stream_for('request body'),
-            ['BadHeader' => 'BadValue']
+            ['BadHeader' => 'BadValue', 'Content-Length' => '123']
         );
         $request = $request->withAttribute('_encoder', 'value');
 
@@ -71,6 +72,7 @@ final class RequestProxyFactoryTest extends TestCase
 
         self::assertSame($expectedUri, (string)$result->getUri());
         self::assertSame('', $result->getHeaderLine('Authorization'));
+        self::assertSame('', $result->getHeaderLine('Content-Length'));
         self::assertSame('', $result->getHeaderLine('BadHeader'));
         self::assertSame('request body', (string)$result->getBody());
         self::assertInstanceOf(ServerRequest::class, $result);


### PR DESCRIPTION
Ticket https://eonx.atlassian.net/browse/PYMT-1595

This change removes all headers from the ElasticSearch queries, except for Content-Type, and the optional Authorization header.

Ping Edward after this is merged.